### PR TITLE
feat: implement the registration server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -394,8 +394,7 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+source = "git+https://github.com/nubicle/h2?branch=patch-authority#5c2f3ab302e6430d86ce6a612438d5e13155074e"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1154,7 +1153,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1456,7 +1455,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,10 @@ tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14.5"
+
+[patch.crates-io]
+# Patch is still needed, using one from upstream PR for now, hosted on a fork of ours to help
+# with supply chain integrity.
+# h2 PR #487 — skip :authority validation for Unix domain sockets
+# Remove once https://github.com/hyperium/h2/pull/487 is merged and released
+h2 = { git = 'https://github.com/nubicle/h2', branch = 'patch-authority'}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ No equivalent exists for Rust. `kube-dra` aims to fill that gap.
   - [ ] Error types
 - [ ] Full plugin lifecycle - `KubeletPluginBuilder`
   - [x] Configuration
-  - [x] Start, and stop,
+  - [x] Start and stop
   - [ ] Rolling update support
 - [ ] DRA handlers
   - [ ] `NodePrepareResources` and `NodeUnprepareResources`

--- a/README.md
+++ b/README.md
@@ -25,13 +25,15 @@ No equivalent exists for Rust. `kube-dra` aims to fill that gap.
 - [ ] Minimal kubelet-visible plugin
   - [x] `Endpoint` — Unix socket lifecycle
   - [ ] `GrpcServer` — non-blocking tonic gRPC server
-  - [ ] `RegistrationServer`
+  - [x] `RegistrationServer`
   - [ ] `NodeRegistrar`
 - [ ] Public API surface
   - [ ] `DraPlugin` trait, `PrepareResult`, `Device`, `NamespacedObject`
   - [ ] Error types
-- [ ] Full plugin lifecycle
-  - [ ] `KubeletPluginBuilder` — configuration, start, stop, and rolling update support
+- [ ] Full plugin lifecycle - `KubeletPluginBuilder`
+  - [x] Configuration
+  - [x] Start, and stop,
+  - [ ] Rolling update support
 - [ ] DRA handlers
   - [ ] `NodePrepareResources` and `NodeUnprepareResources`
 - [ ] `ResourceSlice` publishing

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -5,16 +5,17 @@ use tokio::net::UnixListener;
 // Endpoint defines where and how to listen for incoming connections.
 // A listener for a Unix domain socket gets created at the path.
 // The listener always gets closed when shutting down.
+#[derive(Clone)]
 pub(crate) struct Endpoint {
     dir: PathBuf,
     file: String,
 }
 
 impl Endpoint {
-    pub(crate) fn new(dir: impl Into<PathBuf>, file: &str) -> Self {
+    pub(crate) fn new(dir: impl Into<PathBuf>, file: impl Into<String>) -> Self {
         Endpoint {
             dir: dir.into(),
-            file: file.to_string(),
+            file: file.into(),
         }
     }
 

--- a/src/v1_34/dra_server.rs
+++ b/src/v1_34/dra_server.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+
+use crate::endpoint::Endpoint;
+use crate::v1_34::dra::v1 as drav1;
+use crate::v1_34::dra::v1beta1 as drav1beta1;
+
+// DraServer implements the DraPlugin gRPC service.
+pub(super) struct DraServer {
+    pub(super) driver_name: String,
+    pub(super) grpc_verbosity: i8,
+    pub(super) kube_client: kube::Client,
+    pub(super) node_name: String,
+    pub(super) endpoint: Endpoint,
+}
+
+#[tonic::async_trait]
+impl drav1::dra_plugin_server::DraPlugin for Arc<DraServer> {
+    async fn node_prepare_resources(
+        &self,
+        _request: tonic::Request<drav1::NodePrepareResourcesRequest>,
+    ) -> Result<tonic::Response<drav1::NodePrepareResourcesResponse>, tonic::Status> {
+        todo!()
+    }
+
+    async fn node_unprepare_resources(
+        &self,
+        _request: tonic::Request<drav1::NodeUnprepareResourcesRequest>,
+    ) -> Result<tonic::Response<drav1::NodeUnprepareResourcesResponse>, tonic::Status> {
+        todo!()
+    }
+}
+
+#[tonic::async_trait]
+impl drav1beta1::dra_plugin_server::DraPlugin for Arc<DraServer> {
+    async fn node_prepare_resources(
+        &self,
+        _request: tonic::Request<drav1beta1::NodePrepareResourcesRequest>,
+    ) -> Result<tonic::Response<drav1beta1::NodePrepareResourcesResponse>, tonic::Status> {
+        todo!()
+    }
+
+    async fn node_unprepare_resources(
+        &self,
+        _request: tonic::Request<drav1beta1::NodeUnprepareResourcesRequest>,
+    ) -> Result<tonic::Response<drav1beta1::NodeUnprepareResourcesResponse>, tonic::Status> {
+        todo!()
+    }
+}

--- a/src/v1_34/mod.rs
+++ b/src/v1_34/mod.rs
@@ -20,5 +20,6 @@ mod plugin_registration {
     }
 }
 
+mod dra_server;
 pub(super) mod plugin;
 mod registration;

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -37,6 +37,10 @@ impl KubeletPlugin {
     /// one for the DRA node client) and implements them by calling a [DRAPlugin]
     /// implementation.
     pub async fn start(&mut self) -> anyhow::Result<()> {
+        if self.cancel_token.is_some() {
+            return Err(anyhow!("plugin already started"));
+        }
+
         let dra_listener = self.dra_server.endpoint.listen().await?;
         let reg_listener = self.reg_server.endpoint.listen().await?;
 
@@ -68,13 +72,8 @@ impl KubeletPlugin {
             handle.await??;
         }
 
-        tokio::fs::remove_file(self.dra_server.endpoint.path())
-            .await
-            .ok();
-
-        tokio::fs::remove_file(self.reg_server.endpoint.path())
-            .await
-            .ok();
+        tokio::fs::remove_file(self.dra_server.endpoint.path()).await?;
+        tokio::fs::remove_file(self.reg_server.endpoint.path()).await?;
 
         Ok(())
     }

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use tokio_stream::wrappers::UnixListenerStream;
+use tokio_util::sync::CancellationToken;
 
 use super::dra_server::DraServer;
 use super::registration::RegistrationServer;
@@ -22,6 +23,7 @@ const DEFAULT_GRPC_VERBOSITY: i8 = 6;
 pub struct KubeletPlugin {
     dra_server: Arc<DraServer>,
     reg_server: RegistrationServer,
+    cancel_token: Option<CancellationToken>,
 }
 
 impl KubeletPlugin {
@@ -32,19 +34,33 @@ impl KubeletPlugin {
     /// Start sets up all enabled gRPC servers (by default, one for registration,
     /// one for the DRA node client) and implements them by calling a [DRAPlugin]
     /// implementation.
-    pub async fn start(&self) -> anyhow::Result<()> {
+    pub async fn start(&mut self) -> anyhow::Result<()> {
+        self.cancel_token = Some(CancellationToken::new());
         tokio::try_join!(self.start_plugin_server(), self.start_registration_server(),)?;
 
         Ok(())
     }
 
     pub async fn stop(self) -> anyhow::Result<()> {
-        todo!()
+        if let Some(token) = self.cancel_token {
+            token.cancel();
+        }
+
+        tokio::fs::remove_file(self.dra_server.endpoint.path())
+            .await
+            .ok();
+
+        tokio::fs::remove_file(self.reg_server.endpoint.path())
+            .await
+            .ok();
+
+        Ok(())
     }
 
     async fn start_plugin_server(&self) -> anyhow::Result<()> {
         let listener = self.dra_server.endpoint.listen().await?;
         let stream = UnixListenerStream::new(listener);
+        let token = self.cancel_token.as_ref().unwrap().clone();
 
         tonic::transport::Server::builder()
             .add_service(drav1::dra_plugin_server::DraPluginServer::new(
@@ -53,7 +69,7 @@ impl KubeletPlugin {
             .add_service(drav1beta1::dra_plugin_server::DraPluginServer::new(
                 self.dra_server.clone(),
             ))
-            .serve_with_incoming(stream)
+            .serve_with_incoming_shutdown(stream, token.cancelled())
             .await?;
 
         Ok(())
@@ -62,12 +78,13 @@ impl KubeletPlugin {
     async fn start_registration_server(&self) -> anyhow::Result<()> {
         let listener = self.reg_server.endpoint.listen().await?;
         let stream = UnixListenerStream::new(listener);
+        let token = self.cancel_token.as_ref().unwrap().clone();
 
         tonic::transport::Server::builder()
             .add_service(regv1::registration_server::RegistrationServer::new(
                 self.reg_server.clone(),
             ))
-            .serve_with_incoming(stream)
+            .serve_with_incoming_shutdown(stream, token.cancelled())
             .await?;
 
         Ok(())
@@ -193,6 +210,7 @@ impl KubeletPluginBuilder {
                 ),
                 driver_name: driver_name.to_owned(),
             },
+            cancel_token: None,
         })
     }
 }

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -1,6 +1,15 @@
 use std::path::{self, PathBuf};
+use std::sync::Arc;
 
 use anyhow::anyhow;
+use tokio_stream::wrappers::UnixListenerStream;
+
+use super::dra_server::DraServer;
+use super::registration::RegistrationServer;
+use crate::endpoint::Endpoint;
+use crate::v1_34::dra::v1 as drav1;
+use crate::v1_34::dra::v1beta1 as drav1beta1;
+use crate::v1_34::plugin_registration::v1 as regv1;
 
 /// KUBELET_PLUGINS_DIR is the default directory for [PluginDataDirectoryPath].
 const KUBELET_PLUGINS_DIR: &str = "/var/lib/kubelet/plugins";
@@ -11,11 +20,8 @@ const KUBELET_REGISTRY_DIR: &str = "/var/lib/kubelet/plugins_registry";
 const DEFAULT_GRPC_VERBOSITY: i8 = 6;
 
 pub struct KubeletPlugin {
-    driver_name: String,
-    grpc_verbosity: i8,
-    kube_client: kube::Client,
-    node_name: String,
-    plugin_data_dir: PathBuf,
+    dra_server: Arc<DraServer>,
+    reg_server: RegistrationServer,
 }
 
 impl KubeletPlugin {
@@ -27,11 +33,44 @@ impl KubeletPlugin {
     /// one for the DRA node client) and implements them by calling a [DRAPlugin]
     /// implementation.
     pub async fn start(&self) -> anyhow::Result<()> {
-        todo!()
+        tokio::try_join!(self.start_plugin_server(), self.start_registration_server(),)?;
+
+        Ok(())
     }
 
     pub async fn stop(self) -> anyhow::Result<()> {
         todo!()
+    }
+
+    async fn start_plugin_server(&self) -> anyhow::Result<()> {
+        let listener = self.dra_server.endpoint.listen().await?;
+        let stream = UnixListenerStream::new(listener);
+
+        tonic::transport::Server::builder()
+            .add_service(drav1::dra_plugin_server::DraPluginServer::new(
+                self.dra_server.clone(),
+            ))
+            .add_service(drav1beta1::dra_plugin_server::DraPluginServer::new(
+                self.dra_server.clone(),
+            ))
+            .serve_with_incoming(stream)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn start_registration_server(&self) -> anyhow::Result<()> {
+        let listener = self.reg_server.endpoint.listen().await?;
+        let stream = UnixListenerStream::new(listener);
+
+        tonic::transport::Server::builder()
+            .add_service(regv1::registration_server::RegistrationServer::new(
+                self.reg_server.clone(),
+            ))
+            .serve_with_incoming(stream)
+            .await?;
+
+        Ok(())
     }
 }
 
@@ -42,6 +81,7 @@ pub struct KubeletPluginBuilder {
     kube_client: Option<kube::Client>,
     node_name: Option<String>,
     plugin_data_dir: Option<PathBuf>,
+    plugin_registration_dir: Option<PathBuf>,
 }
 
 impl KubeletPluginBuilder {
@@ -99,6 +139,19 @@ impl KubeletPluginBuilder {
         self
     }
 
+    /// RegistrarDirectoryPath sets the path to the directory where the kubelet
+    /// expects to find registration sockets of plugins. Typically this is
+    /// `/var/lib/kubelet/plugins_registry` with `/var/lib/kubelet` being the kubelet's
+    /// data directory.
+    ///
+    /// This is also the default. Some Kubernetes clusters may use a different data directory.
+    /// This path must be the same inside and outside of the driver's container.
+    /// The directory must exist.
+    pub fn registrar_directory_path(&mut self, dir: impl Into<PathBuf>) -> &mut Self {
+        self.plugin_registration_dir = Some(dir.into());
+        self
+    }
+
     pub fn build(&mut self) -> anyhow::Result<KubeletPlugin> {
         let driver_name = self
             .driver_name
@@ -115,18 +168,31 @@ impl KubeletPluginBuilder {
             .as_ref()
             .ok_or_else(|| anyhow!("node name is required"))?;
 
-        let plugin_data_dir = if self.plugin_data_dir.is_some() {
-            self.plugin_data_dir.clone().unwrap()
-        } else {
-            PathBuf::from(format!("{KUBELET_PLUGINS_DIR}/{}", driver_name.clone()))
-        };
+        let plugin_data_dir = self
+            .plugin_data_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(format!("{KUBELET_PLUGINS_DIR}/{}", driver_name)));
+
+        let plugin_registration_dir = self
+            .plugin_registration_dir
+            .clone()
+            .unwrap_or(PathBuf::from(KUBELET_REGISTRY_DIR));
 
         Ok(KubeletPlugin {
-            driver_name: driver_name.to_owned(),
-            grpc_verbosity: self.grpc_verbosity.unwrap_or(DEFAULT_GRPC_VERBOSITY),
-            kube_client: kube_client.to_owned(),
-            node_name: node_name.to_owned(),
-            plugin_data_dir: plugin_data_dir,
+            dra_server: Arc::new(DraServer {
+                driver_name: driver_name.to_owned(),
+                grpc_verbosity: self.grpc_verbosity.unwrap_or(DEFAULT_GRPC_VERBOSITY),
+                kube_client: kube_client.to_owned(),
+                node_name: node_name.to_owned(),
+                endpoint: Endpoint::new(plugin_data_dir, "dra.sock"),
+            }),
+            reg_server: RegistrationServer {
+                endpoint: Endpoint::new(
+                    plugin_registration_dir,
+                    format!("{}-reg.sock", driver_name),
+                ),
+                driver_name: driver_name.to_owned(),
+            },
         })
     }
 }

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -24,6 +24,7 @@ pub struct KubeletPlugin {
     dra_server: Arc<DraServer>,
     reg_server: RegistrationServer,
     cancel_token: Option<CancellationToken>,
+    handles: Vec<tokio::task::JoinHandle<anyhow::Result<()>>>,
 }
 
 impl KubeletPlugin {
@@ -35,8 +36,16 @@ impl KubeletPlugin {
     /// one for the DRA node client) and implements them by calling a [DRAPlugin]
     /// implementation.
     pub async fn start(&mut self) -> anyhow::Result<()> {
-        self.cancel_token = Some(CancellationToken::new());
-        tokio::try_join!(self.start_plugin_server(), self.start_registration_server(),)?;
+        let token = CancellationToken::new();
+        self.cancel_token = Some(token.clone());
+
+        let dra_handle = tokio::spawn(start_plugin_server(self.dra_server.clone(), token.clone()));
+        let reg_handle = tokio::spawn(start_registration_server(
+            self.reg_server.clone(),
+            token.clone(),
+        ));
+
+        self.handles = vec![dra_handle, reg_handle];
 
         Ok(())
     }
@@ -44,6 +53,10 @@ impl KubeletPlugin {
     pub async fn stop(self) -> anyhow::Result<()> {
         if let Some(token) = self.cancel_token {
             token.cancel();
+        }
+
+        for handle in self.handles {
+            handle.await??;
         }
 
         tokio::fs::remove_file(self.dra_server.endpoint.path())
@@ -56,39 +69,41 @@ impl KubeletPlugin {
 
         Ok(())
     }
+}
 
-    async fn start_plugin_server(&self) -> anyhow::Result<()> {
-        let listener = self.dra_server.endpoint.listen().await?;
-        let stream = UnixListenerStream::new(listener);
-        let token = self.cancel_token.as_ref().unwrap().clone();
+async fn start_plugin_server(
+    server: Arc<DraServer>,
+    token: CancellationToken,
+) -> anyhow::Result<()> {
+    let listener = server.endpoint.listen().await?;
+    let stream = UnixListenerStream::new(listener);
 
-        tonic::transport::Server::builder()
-            .add_service(drav1::dra_plugin_server::DraPluginServer::new(
-                self.dra_server.clone(),
-            ))
-            .add_service(drav1beta1::dra_plugin_server::DraPluginServer::new(
-                self.dra_server.clone(),
-            ))
-            .serve_with_incoming_shutdown(stream, token.cancelled())
-            .await?;
+    tonic::transport::Server::builder()
+        .add_service(drav1::dra_plugin_server::DraPluginServer::new(
+            server.clone(),
+        ))
+        .add_service(drav1beta1::dra_plugin_server::DraPluginServer::new(
+            server.clone(),
+        ))
+        .serve_with_incoming_shutdown(stream, token.cancelled())
+        .await?;
 
-        Ok(())
-    }
+    Ok(())
+}
 
-    async fn start_registration_server(&self) -> anyhow::Result<()> {
-        let listener = self.reg_server.endpoint.listen().await?;
-        let stream = UnixListenerStream::new(listener);
-        let token = self.cancel_token.as_ref().unwrap().clone();
+async fn start_registration_server(
+    server: RegistrationServer,
+    token: CancellationToken,
+) -> anyhow::Result<()> {
+    let listener = server.endpoint.listen().await?;
+    let stream = UnixListenerStream::new(listener);
 
-        tonic::transport::Server::builder()
-            .add_service(regv1::registration_server::RegistrationServer::new(
-                self.reg_server.clone(),
-            ))
-            .serve_with_incoming_shutdown(stream, token.cancelled())
-            .await?;
+    tonic::transport::Server::builder()
+        .add_service(regv1::registration_server::RegistrationServer::new(server))
+        .serve_with_incoming_shutdown(stream, token.cancelled())
+        .await?;
 
-        Ok(())
-    }
+    Ok(())
 }
 
 #[derive(Default)]
@@ -211,6 +226,7 @@ impl KubeletPluginBuilder {
                 driver_name: driver_name.to_owned(),
             },
             cancel_token: None,
+            handles: Vec::default(),
         })
     }
 }

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -2,6 +2,7 @@ use std::path::{self, PathBuf};
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use tokio::net::UnixListener;
 use tokio_stream::wrappers::UnixListenerStream;
 use tokio_util::sync::CancellationToken;
 
@@ -36,12 +37,20 @@ impl KubeletPlugin {
     /// one for the DRA node client) and implements them by calling a [DRAPlugin]
     /// implementation.
     pub async fn start(&mut self) -> anyhow::Result<()> {
+        let dra_listener = self.dra_server.endpoint.listen().await?;
+        let reg_listener = self.reg_server.endpoint.listen().await?;
+
         let token = CancellationToken::new();
         self.cancel_token = Some(token.clone());
 
-        let dra_handle = tokio::spawn(start_plugin_server(self.dra_server.clone(), token.clone()));
+        let dra_handle = tokio::spawn(start_plugin_server(
+            self.dra_server.clone(),
+            dra_listener,
+            token.clone(),
+        ));
         let reg_handle = tokio::spawn(start_registration_server(
             self.reg_server.clone(),
+            reg_listener,
             token.clone(),
         ));
 
@@ -73,11 +82,9 @@ impl KubeletPlugin {
 
 async fn start_plugin_server(
     server: Arc<DraServer>,
+    listener: UnixListener,
     token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let listener = server.endpoint.listen().await?;
-    let stream = UnixListenerStream::new(listener);
-
     tonic::transport::Server::builder()
         .add_service(drav1::dra_plugin_server::DraPluginServer::new(
             server.clone(),
@@ -85,7 +92,7 @@ async fn start_plugin_server(
         .add_service(drav1beta1::dra_plugin_server::DraPluginServer::new(
             server.clone(),
         ))
-        .serve_with_incoming_shutdown(stream, token.cancelled())
+        .serve_with_incoming_shutdown(UnixListenerStream::new(listener), token.cancelled())
         .await?;
 
     Ok(())
@@ -93,14 +100,12 @@ async fn start_plugin_server(
 
 async fn start_registration_server(
     server: RegistrationServer,
+    listener: UnixListener,
     token: CancellationToken,
 ) -> anyhow::Result<()> {
-    let listener = server.endpoint.listen().await?;
-    let stream = UnixListenerStream::new(listener);
-
     tonic::transport::Server::builder()
         .add_service(regv1::registration_server::RegistrationServer::new(server))
-        .serve_with_incoming_shutdown(stream, token.cancelled())
+        .serve_with_incoming_shutdown(UnixListenerStream::new(listener), token.cancelled())
         .await?;
 
     Ok(())

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -72,8 +72,17 @@ impl KubeletPlugin {
             handle.await??;
         }
 
-        tokio::fs::remove_file(self.dra_server.endpoint.path()).await?;
-        tokio::fs::remove_file(self.reg_server.endpoint.path()).await?;
+        if let Err(err) = tokio::fs::remove_file(self.dra_server.endpoint.path()).await {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(err.into());
+            }
+        }
+
+        if let Err(err) = tokio::fs::remove_file(self.reg_server.endpoint.path()).await {
+            if err.kind() != std::io::ErrorKind::NotFound {
+                return Err(err.into());
+            }
+        }
 
         Ok(())
     }

--- a/src/v1_34/plugin.rs
+++ b/src/v1_34/plugin.rs
@@ -210,21 +210,23 @@ impl KubeletPluginBuilder {
             .clone()
             .unwrap_or(PathBuf::from(KUBELET_REGISTRY_DIR));
 
+        let dra_endpoint = Endpoint::new(plugin_data_dir, "dra.sock");
         Ok(KubeletPlugin {
+            reg_server: RegistrationServer {
+                driver_name: driver_name.to_owned(),
+                endpoint: Endpoint::new(
+                    plugin_registration_dir,
+                    format!("{}-reg.sock", driver_name),
+                ),
+                dra_endpoint_path: dra_endpoint.path(),
+            },
             dra_server: Arc::new(DraServer {
                 driver_name: driver_name.to_owned(),
                 grpc_verbosity: self.grpc_verbosity.unwrap_or(DEFAULT_GRPC_VERBOSITY),
                 kube_client: kube_client.to_owned(),
                 node_name: node_name.to_owned(),
-                endpoint: Endpoint::new(plugin_data_dir, "dra.sock"),
+                endpoint: dra_endpoint,
             }),
-            reg_server: RegistrationServer {
-                endpoint: Endpoint::new(
-                    plugin_registration_dir,
-                    format!("{}-reg.sock", driver_name),
-                ),
-                driver_name: driver_name.to_owned(),
-            },
             cancel_token: None,
             handles: Vec::default(),
         })

--- a/src/v1_34/registration.rs
+++ b/src/v1_34/registration.rs
@@ -1,40 +1,34 @@
 use tonic::{Request, Response};
 
-use super::dra;
-use super::plugin_registration::v1::{self, registration_server::Registration};
+use crate::endpoint::Endpoint;
+use crate::v1_34::dra::v1 as drav1;
+use crate::v1_34::dra::v1beta1 as drav1beta1;
+use crate::v1_34::plugin_registration::v1 as regv1;
 
 /// DRAPlugin identifier for registered Dynamic Resource Allocation plugins.
 const PLUGIN_TYPE: &str = "DRAPlugin";
 
 // RegistrationServer implements the kubelet plugin registration gRPC service.
+#[derive(Clone)]
 pub(super) struct RegistrationServer {
-    driver_name: String,
-    endpoint: String,
-}
-
-impl RegistrationServer {
-    pub fn new(driver_name: &str, endpoint: &str) -> Self {
-        RegistrationServer {
-            driver_name: driver_name.to_string(),
-            endpoint: endpoint.to_string(),
-        }
-    }
+    pub(super) driver_name: String,
+    pub(super) endpoint: Endpoint,
 }
 
 #[tonic::async_trait]
-impl Registration for RegistrationServer {
+impl regv1::registration_server::Registration for RegistrationServer {
     /// get_info is the RPC invoked by plugin watcher.
     async fn get_info(
         &self,
-        _: Request<v1::InfoRequest>,
-    ) -> Result<Response<v1::PluginInfo>, tonic::Status> {
-        let info = v1::PluginInfo {
+        _: Request<regv1::InfoRequest>,
+    ) -> Result<Response<regv1::PluginInfo>, tonic::Status> {
+        let info = regv1::PluginInfo {
             name: self.driver_name.clone(),
-            endpoint: self.endpoint.clone(),
+            endpoint: self.endpoint.path().to_string_lossy().to_string(),
             r#type: String::from(PLUGIN_TYPE),
             supported_versions: vec![
-                dra::v1::dra_plugin_server::SERVICE_NAME.to_string(),
-                dra::v1beta1::dra_plugin_server::SERVICE_NAME.to_string(),
+                short_service_name(drav1::dra_plugin_server::SERVICE_NAME),
+                short_service_name(drav1beta1::dra_plugin_server::SERVICE_NAME),
             ],
         };
 
@@ -44,8 +38,8 @@ impl Registration for RegistrationServer {
     /// notify_registration_status is the RPC invoked by plugin watcher.
     async fn notify_registration_status(
         &self,
-        status: Request<v1::RegistrationStatus>,
-    ) -> Result<Response<v1::RegistrationStatusResponse>, tonic::Status> {
+        status: Request<regv1::RegistrationStatus>,
+    ) -> Result<Response<regv1::RegistrationStatusResponse>, tonic::Status> {
         let status = status.into_inner();
 
         if !status.plugin_registered {
@@ -62,6 +56,28 @@ impl Registration for RegistrationServer {
         }
 
         tracing::info!(driver = %self.driver_name, "registration successful");
-        Ok(Response::new(v1::RegistrationStatusResponse::default()))
+        Ok(Response::new(regv1::RegistrationStatusResponse::default()))
+    }
+}
+
+fn short_service_name(svc: &str) -> String {
+    let mut parts = svc.rsplitn(3, '.');
+    let last = parts.next().unwrap_or("");
+    let second_last = parts.next().unwrap_or("");
+    format!("{second_last}.{last}")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v1_34::dra::v1 as drav1;
+    use crate::v1_34::dra::v1beta1 as drav1beta1;
+
+    #[test]
+    fn generates_correct_short_name() {
+        let v1_svc = super::short_service_name(drav1::dra_plugin_server::SERVICE_NAME);
+        assert_eq!(v1_svc, String::from("v1.DRAPlugin"));
+
+        let v1beta1_svc = super::short_service_name(drav1beta1::dra_plugin_server::SERVICE_NAME);
+        assert_eq!(v1beta1_svc, String::from("v1beta1.DRAPlugin"));
     }
 }

--- a/src/v1_34/registration.rs
+++ b/src/v1_34/registration.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use tonic::{Request, Response};
 
 use crate::endpoint::Endpoint;
@@ -13,6 +15,7 @@ const PLUGIN_TYPE: &str = "DRAPlugin";
 pub(super) struct RegistrationServer {
     pub(super) driver_name: String,
     pub(super) endpoint: Endpoint,
+    pub(super) dra_endpoint_path: PathBuf,
 }
 
 #[tonic::async_trait]
@@ -24,7 +27,7 @@ impl regv1::registration_server::Registration for RegistrationServer {
     ) -> Result<Response<regv1::PluginInfo>, tonic::Status> {
         let info = regv1::PluginInfo {
             name: self.driver_name.clone(),
-            endpoint: self.endpoint.path().to_string_lossy().to_string(),
+            endpoint: self.dra_endpoint_path.to_string_lossy().to_string(),
             r#type: String::from(PLUGIN_TYPE),
             supported_versions: vec![
                 short_service_name(drav1::dra_plugin_server::SERVICE_NAME),


### PR DESCRIPTION
```sh
☸ kind-kind (kube-dra) in ~
❯ kubectl logs example-driver-kubeletplugin-4dqxh
2026-03-31T21:45:10.582187Z  INFO example_driver::driver: initializing driver driver=gpu.example.com
2026-03-31T21:45:10.582668Z  INFO example_driver::driver: driver started driver=gpu.example.com
2026-03-31T21:45:10.975750Z  INFO kube_dra::v1_34::registration: registration successful driver=gpu.example.com
```